### PR TITLE
chore: add 'canary' term to versions published as canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,7 +28,7 @@ jobs:
 
       - run: |
           CURRENT_VERSION=$(pnpm pkg get version | tr -d \")
-          CANARY_VERSION=$CURRENT_VERSION-${{ github.sha }}
+          CANARY_VERSION="$CURRENT_VERSION-canary-${{ github.sha }}"
           pnpm version --prerelease $CANARY_VERSION --git-tag-version=false
           pnpm publish --tag canary --no-git-checks
         env:


### PR DESCRIPTION
added term 'canary' to published version naming convention
testing github branch protection policies
