### PR TITLE
proposal: pop, drop, lock mode 🔒

### DIFF
--- a/src/components/ClickPopup.tsx
+++ b/src/components/ClickPopup.tsx
@@ -9,11 +9,13 @@ const DefaultPopupOptions: Partial<PopupOptions> = {
 };
 type ClickPopupProps = {
   layerId: string;
+  locked?: boolean;
   options?: Partial<PopupOptions>;
   children: (e: PopupEvent) => React.ReactNode;
 };
 const ClickPopup: React.FC<ClickPopupProps> = ({
   layerId,
+  locked = false,
   options,
   children,
 }) => {
@@ -33,6 +35,7 @@ const ClickPopup: React.FC<ClickPopupProps> = ({
     type: "click",
     layerId,
     callback: (e) => {
+      if (locked) return; // 🔒 Prevent creating new popups when locked
       if (!containerRef.current) return;
       if (!map) return;
       const features = e.features || [];


### PR DESCRIPTION
WE need to look a way to "lock" layers (I can explain, right now I can barely open my eyes and unfortunately do not have the bestest type energy) .. the `Layer` part I can currently just do independently (but I have a half-ass idea for a `LayerGroup` component, if you're interested) .. but it'd be nice to implement this in the actual exported lib `ClickPopup` because there's not a clean way for me to override 'default' ClickPopup click behavior as is.

[This will keep the current Popup that's rendered in place, but not allow for any other Popups until the `locked` is released]
